### PR TITLE
docs: forgot to add minikube to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ A [`terragrunt`](https://github.com/gruntwork-io/terragrunt) module for [`miniku
 
 | name                                                     |
 |----------------------------------------------------------|
-| [pyenv](https://github.com/pyenv/pyenv)                  |
-| [poetry](https://github.com/python-poetry)               |
 | [docker](https://github.com/docker)                      |
 | [kubectl](https://github.com/kubernetes/kubectl)         |
 | [terragrunt](https://github.com/gruntwork-io/terragrunt) |

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A [`terragrunt`](https://github.com/gruntwork-io/terragrunt) module for [`miniku
 | name                                                     |
 |----------------------------------------------------------|
 | [docker](https://github.com/docker)                      |
+| [minikube](https://github.com/kubernetes/minikube)       |
 | [kubectl](https://github.com/kubernetes/kubectl)         |
 | [terragrunt](https://github.com/gruntwork-io/terragrunt) |
 | [terraform](https://github.com/hashicorp/terraform)      |


### PR DESCRIPTION
I forgot to add `minikube` as a dependency in the README. 