### PR TITLE
revert: remove `poetry` references in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,6 @@ A [`terragrunt`](https://github.com/gruntwork-io/terragrunt) module for [`miniku
 
 ```shell
 pre-commit install
-poetry install
-poetry shell
 ```
 
 ## Usage


### PR DESCRIPTION
Again, forgot to remove the `poetry` references from the README in a different section. 