### PR TITLE
refactor: missing `kustomize` and `helm` in install table

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,17 @@ A [`terragrunt`](https://github.com/gruntwork-io/terragrunt) module for [`miniku
 
 ## Install
 
-| name                                                     |
-|----------------------------------------------------------|
-| [docker](https://github.com/docker)                      |
-| [minikube](https://github.com/kubernetes/minikube)       |
-| [kubectl](https://github.com/kubernetes/kubectl)         |
-| [terragrunt](https://github.com/gruntwork-io/terragrunt) |
-| [terraform](https://github.com/hashicorp/terraform)      |
-| [opentofu](https://github.com/opentofu/opentofu)         |
-| [pre-commit](https://github.com/pre-commit/pre-commit)   |
+| name                                                      |
+|-----------------------------------------------------------|
+| [docker](https://github.com/docker)                       |
+| [minikube](https://github.com/kubernetes/minikube)        |
+| [kubectl](https://github.com/kubernetes/kubectl)          |
+| [kustomize](https://github.com/kubernetes-sigs/kustomize) |
+| [helm](https://github.com/helm/helm)                      |
+| [terragrunt](https://github.com/gruntwork-io/terragrunt)  |
+| [terraform](https://github.com/hashicorp/terraform)       |
+| [opentofu](https://github.com/opentofu/opentofu)          |
+| [pre-commit](https://github.com/pre-commit/pre-commit)    |
 
 ```shell
 pre-commit install


### PR DESCRIPTION
There's a few more missing dependencies needing to be added to the install table. 